### PR TITLE
Match Noita's duplicate attribute behaviour

### DIFF
--- a/nxml.lua
+++ b/nxml.lua
@@ -378,6 +378,10 @@ function PARSER_FUNCS:parse_attr(attr_table, name)
 		end
 
 		if tok.type == "string" then
+			if attr_table[name] ~= nil then
+				self:report_error("duplicate_attribute", string.format("parsing attribute '%s' - attribute already exists", name))
+				return
+			end
 			attr_table[name] = tok.value
 		else
 			self:report_error(

--- a/test.lua
+++ b/test.lua
@@ -17,3 +17,7 @@ print(tostring(tree))
 print(nxml.tostring(tree, true))
 tree:add_child(nxml.parse("<Entity />"))
 print(tree)
+
+
+local dup_name = nxml.parse([[<Entity name="a" name="b" />]])
+assert(dup_name.attr.name == "a")


### PR DESCRIPTION
In-game test to confirm this behaviour:

```lua
ModTextFileSetContent("mods/t.xml", [[
<Entity name="a" name="b" />
]])
e = EntityLoad("mods/t.xml")
return EntityGetName(e)
```
Result: `"a"`